### PR TITLE
chore(@avelino-samba/utils): config workflow

### DIFF
--- a/.github/workflows/utils-build.yml
+++ b/.github/workflows/utils-build.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: Utils - [Lint, Test & Build]
 
 on:
@@ -10,28 +7,66 @@ on:
       - "packages/tsconfig/**"
       - "packages/lint-config/**"
       - ".github/workflows/utils-build.yml"
+      - "package.json"
+
+env:
+  NODE_VERSION: 18.x
 
 jobs:
-  lint:
-    name: "Step - Lint"
+  install:
+    name: "Step - Install Dependencies"
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [$NODE_VERSION]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            packages/utils/node_modules
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: "yarn"
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Dependencies
         run: yarn workspace @avelino-samba/utils install --frozen-lockfile
+
+  lint:
+    name: "Step - Lint"
+
+    runs-on: ubuntu-latest
+
+    needs: [install]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            packages/utils/node_modules
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Check linting
         run: yarn workspace @avelino-samba/utils prettier:check
@@ -41,21 +76,25 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
+    needs: [install]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            packages/utils/node_modules
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - name: Install Dependencies
-        run: yarn workspace @avelino-samba/utils install
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Check tests
         run: yarn workspace @avelino-samba/utils test
@@ -65,21 +104,25 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
+    needs: [install]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            packages/utils/node_modules
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - name: Install Dependencies
-        run: yarn workspace @avelino-samba/utils install
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Build
         run: yarn workspace @avelino-samba/utils build


### PR DESCRIPTION
# Explicação para o cacheamento no workflow

```yml

 - name: Cache dependencies
        uses: actions/cache@v2
        with:
          path: |
            packages/utils/node_modules
            node_modules
          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
          restore-keys: |
            ${{ runner.os }}-node-

```

Essa parte do arquivo YAML é responsável por armazenar o cache das dependências instaladas no passo de install e recuperá-las em outras etapas.

O `actions/cache@v2` é uma ação do GitHub que permite armazenar e recuperar arquivos de cache durante uma execução do fluxo de trabalho. Ela utiliza uma chave de cache para identificar e recuperar o cache armazenado.

Na seção `with`, especifica-se o caminho do diretório a ser armazenado em cache, que nesse caso é `packages/utils/node_modules` (para armazenar as dependências do pacote atual) e node_modules (para armazenar as dependências da raiz do monorepo).

Além disso, a chave de cache é definida por `${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}`. Ela inclui o sistema operacional em que o fluxo de trabalho está sendo executado (`runner.os`), a versão do Node.js (`node`), e um hash dos arquivos yarn.lock em todos os diretórios (`**/yarn.lock`). Isso garante que uma nova chave seja gerada sempre que os arquivos `yarn.lock` mudem, garantindo a integridade do cache.

Por fim, a seção `restore-keys` é utilizada para especificar as chaves de cache a serem usadas para tentar recuperar o cache em caso de falha ao recuperar a chave principal. No exemplo dado, é utilizado ${{ runner.os }}-node-, o que significa que, se a chave principal não for encontrada, ele tentará recuperar um cache anterior com a mesma prefixo.

